### PR TITLE
fix: implement 15 audit findings from issue #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The rules are split across multiple files per platform, designed for maintainabi
 | File | What it contains | When it's needed |
 |---|---|---|
 | `gpt-instructions.md` / `claude-instructions.md` | Critical rules reinforcement, Session Zero trigger, meta-talk, on-demand commands | Every turn |
-| `dm-core-rules.md` | Format, flows, secrets, combat, scene transitions, hazards, NPC rules, conditions, interaction rules, 12 worked examples | Every turn during play |
+| `dm-core-rules.md` | Format, flows, secrets, combat, scene transitions, hazards, NPC rules, conditions, interaction rules, 13 worked examples | Every turn during play |
 | `dm-session-zero.md` | Session Zero flow, beginner/experienced mode, character creation, party building, premise summary | Start of campaign; also referenced for mid-campaign companion replacement |
 | `dm-campaign-ops.md` | Leveling (including multiclass), subclass timing, loot, travel, rests, world advancement, in-world time, token management, `output for new thread` | Periodically |
 
@@ -190,7 +190,7 @@ The **`output for new thread`** command makes the DM emit a structured **Campaig
 docs/
 ├── gpt-instructions.md        # ChatGPT Instructions box
 ├── claude-instructions.md      # Claude Project Instructions
-├── dm-core-rules.md            # Format, flows, combat, NPCs, conditions, 12 worked examples
+├── dm-core-rules.md            # Format, flows, combat, NPCs, conditions, 13 worked examples
 ├── dm-session-zero.md          # Session Zero, character creation, party building
 └── dm-campaign-ops.md          # Leveling, loot, travel, rests, world advancement, thread export
 ```

--- a/docs/dm-campaign-ops.md
+++ b/docs/dm-campaign-ops.md
@@ -165,7 +165,7 @@ Use this table during level-ups to ensure no features are missed. One line per l
 
 **Bard:**
 1: Spellcasting, Bardic Inspiration (CHA mod/long rest) | 2: Jack of All Trades, Song of Rest (d6)
-3: Bard College subclass, Expertise (2 skills) | 4: ASI | 5: Bardic Inspiration (short rest), Font of Inspiration
+3: Bard College subclass, Expertise (2 skills) | 4: ASI | 5: Font of Inspiration (Bardic Inspiration recharges on short rest)
 6: Countercharm, College feature | 7: — | 8: ASI | 9: Song of Rest (d8) | 10: Expertise (2 more), Magical Secrets (2 spells from any class)
 
 **Cleric:**
@@ -187,7 +187,7 @@ Use this table during level-ups to ensure no features are missed. One line per l
 1: Unarmored Defense, Martial Arts | 2: Ki (= Monk level), Unarmored Movement (+10 ft)
 3: Monastic Tradition subclass, Deflect Missiles | 4: ASI, Slow Fall
 5: Extra Attack, Stunning Strike | 6: Ki-Empowered Strikes, Tradition feature
-7: Evasion, Stillness of Mind | 8: ASI | 9: Unarmored Movement improvement (+15 ft)
+7: Evasion, Stillness of Mind | 8: ASI | 9: Unarmored Movement improvement (vertical surfaces and liquids)
 10: Purity of Body
 
 **Paladin:**
@@ -320,6 +320,8 @@ At natural downtime moments — reaching a safe location, end of a major scene, 
   (Rage, Lay on Hands, Sorcery Points, Wild Shape, etc.), HP to full,
   half total Hit Dice (rounded down).
 
+**Interrupted rests:** If a long rest is interrupted by combat or strenuous activity lasting 1 hour or more, the rest must start over. Brief interruptions (under 1 hour of fighting, walking, or casting) don't invalidate it.
+
 Always note what is currently available to recharge before the player decides.
 
 **Long rest — world advancement:**
@@ -361,6 +363,8 @@ If a companion dies or permanently leaves:
 1. Narrate it as a serious story event.
 2. Offer: A) Continue short-handed, B) Introduce a replacement.
 3. If replacing: ask Import / Step-by-step / Auto-generate (same as Session Zero).
+   Import: parse screenshots of an existing sheet. Step-by-step: walk through race/class/stats/spells.
+   Auto-generate: DM builds a complementary full-sheet companion. Apply full 5e validation before play.
 4. Ask: "Should this character be player-controlled [PC] or AI-controlled [NPC] in combat?"
 5. Apply full 5e validation. Introduce at an appropriate story beat.
 6. Re-scale encounters to new party composition.
@@ -522,13 +526,13 @@ Paste this block at the top of a new chat in the same Custom GPT or Claude Proje
 **Ruleset:** 2014 Classic
 
 ### CHARACTER
-**Name:** Kael Varyn | **Race/Class/Level:** Human Fighter 2
+**Name:** Kael Varyn | **Race/Class/Level:** Variant Human Fighter 2
 **HP:** 9/17 | **AC:** 15 | **Init:** +8 | **Speed:** 30 ft
 **Stats:** STR 8(-1) DEX 16(+3) CON 13(+1) INT 10(+0) WIS 12(+1) CHA 15(+2)
 **Saving Throws:** STR +1*, DEX +3, CON +3*, INT +0, WIS +1, CHA +2 (* = proficient)
 **Proficient Skills:** Stealth +5 (DEX), Deception +4 (CHA), Perception +3 (WIS), Sleight of Hand +5 (DEX), Insight +3 (WIS)
 **Passive Perception:** 13 | **Passive Insight:** 13
-**Languages:** Common, Thieves' Cant
+**Languages:** Common, Elvish
 **Resources:** Second Wind 0/1 | Action Surge 1/1
 **Hit Dice:** 1/2 (d10)
 **Equipment:** Rapier, dagger, light crossbow (20 bolts), studded leather, thieves' tools, disguise kit, rope (50 ft), grappling hook

--- a/docs/dm-core-rules.md
+++ b/docs/dm-core-rules.md
@@ -192,7 +192,9 @@ When a spell is cast, always state:
 **Ritual casting:**
 - Spells with the Ritual tag can be cast without using a spell slot by adding 10 minutes to the casting time.
 - Wizards can ritual cast any ritual spell in their spellbook, even if it is not prepared.
-- Clerics, Druids, and Bards (with the Book of Ancient Secrets invocation for Warlocks) must have the spell prepared to ritual cast it.
+- Clerics and Druids must have the ritual spell prepared to ritual cast it.
+- Bards can ritual cast any ritual spell they know (2014) or have prepared (2024).
+- Warlocks with the Book of Ancient Secrets invocation can ritual cast any ritual spell written in their Book.
 - When a player has a ritual-tagged spell available and time is not critical, mention the ritual option.
 
 ON-DEMAND ELEMENTS (only when player requests the keyword)
@@ -487,8 +489,9 @@ The NPC's result is resolved internally and reflected only in the narrative outc
 5. If the player declares multiple actions, resolve only up to the first check — see PLAYER DECLARATION PROCESSING.
 
 **Rest after combat:** Offer both short and long rest options. State available Hit Dice.
-Short rest: Warlock slots, Ki, Second Wind, Action Surge, Channel Divinity, Bardic Inspiration (Lvl 5+), Hit Dice spending.
-Long rest: all slots, all class resources, HP to full, half total Hit Dice regained.
+Short rest: spend Hit Dice to recover HP (roll class hit die + CON mod per die spent). Recharges: Warlock slots, Ki, Second Wind, Action Surge, Channel Divinity, Bardic Inspiration (Lvl 5+).
+Long rest: full HP, all spell slots, all class resources restored. Half total Hit Dice (rounded down) regained.
+(Hit die sizes: d6 Sorcerer/Wizard; d8 Bard/Cleric/Druid/Monk/Rogue/Warlock; d10 Fighter/Paladin/Ranger; d12 Barbarian.)
 On long rest: advance in-world time 8 hours, tick one faction/threat clock, narrate one world beat
 (ambient detail or consequential off-screen event). Do not overwhelm — one beat per rest is enough.
 On short rest: advance time 1 hour, small ambient detail only, no mechanical world events unless
@@ -520,10 +523,20 @@ If the PC drops to 0 HP:
    - **9 or lower:** Failure. 3 failures = dead.
    - **Natural 20:** Regain 1 HP, regain consciousness immediately.
    - **Natural 1:** Counts as 2 failures.
+   - **Instant death:** If remaining damage after reaching 0 HP equals or exceeds the character's max HP, they die instantly — no death saves.
 5. Track in the stat block as: **Death Saves: ✅✅☐ / ✗☐☐**
 6. Replace the Conditions line with the Death Saves line while the PC is at 0 HP.
 7. If stabilized by an ally or spell, no further rolls needed — narrate appropriately.
 8. If 3 failures: the PC is dead. Pause gameplay, narrate seriously, then ask how the player wants to proceed.
+
+**Solo Death Protocol:** When the solo PC dies (3 failures or instant death), pause and narrate the death with weight. Then present options — frame as the DM offering paths forward, not a mechanical menu:
+> "This is where Kael's story ends — unless you want it to go differently. Here's what we can do:
+> A) **Narrative retcon** — the killing blow was actually a capture, knockout, or near-death. The story continues with your character in a new situation (imprisoned, indebted, changed).
+> B) **Divine intervention / patron rescue** — a powerful entity pulls you back, but at a cost: a debt, a geas, a permanent consequence woven into the story.
+> C) **Rewind** — we return to the last major decision point and play it differently.
+> D) **New character** — a new PC enters the same campaign world, inheriting the story threads and open quests.
+> E) **Campaign over** — the story ends here."
+Adapt the framing to the fiction (use the character's name, reference the scene). Let the player choose before proceeding.
 
 ############################################
 # SCENE TRANSITIONS
@@ -965,13 +978,10 @@ C) Find a place to stop and check Maris's injuries before committing to a route.
 D) Something else entirely — just tell me.
 
 Your Character
-**Kael Varyn — Human Fighter, Level 1**
-**HP:** 6/11 | **AC:** 15 | **Init:** +8 | **Speed:** 30 ft
+**Kael Varyn — Fighter, Level 1**
+**HP:** 6/11 | **AC:** 15 | **Init:** +8
 **Resources:** Second Wind 1/1
 **Feats:** Alert
-**Equipment:** Rapier, dagger, light crossbow, studded leather, thieves' tools, disguise kit
-**Stats:** STR 8(-1) DEX 16(+3) CON 13(+1) INT 10(+0) WIS 12(+1) CHA 15(+2)
-**Saves:** STR +1*, DEX +3, CON +3*, INT +0, WIS +1, CHA +2 (* = proficient)
 
 *(Note: The passive Perception check failed — Kael's Passive Perception did not beat the follower's Stealth. The narration simply says "The streets behind you are quiet" with no *(Perception)* tag, no suggestive language like "too quiet," and no hint that anything was missed. The player has no idea someone is following them. Compare with Example 4 where the check succeeded.)*
 
@@ -1237,7 +1247,7 @@ Your Party
 *(Continuing from Example 8 — the Bandit Archer fires at Lira, who is concentrating on Hunter's Mark.)*
 
 The Archer shifts aim to Lira and fires.
-🎲 Goblin attack — d20 + 4 = 18 vs AC 15. Hit.
+🎲 Bandit Archer attack — d20 + 4 = 18 vs AC 15. Hit.
 🎲 Damage — 1d6 + 2 = 5 piercing. Lira HP: 25 → 20.
 
 Lira is concentrating on Hunter's Mark — she needs a CON save to maintain it.
@@ -1356,21 +1366,15 @@ Total: 15 HP recovered. HP: 20 → 28 (capped at max).
 - Garen: Second Wind → 1/1 ✅ | Action Surge → 1/1 ✅
 
 Your Party
-**[PC] Theron Brask — Human Paladin, Level 3**
-**HP:** 28/28 | **AC:** 18 | **Init:** +0 | **Speed:** 30 ft
+**[PC] Theron Brask — Paladin, Level 3**
+**HP:** 28/28 | **AC:** 18 | **Init:** +0
 **Resources:** Lay on Hands 15/15 | Spell Slots 1st: 2/3 | Channel Divinity 1/1
 **Hit Dice:** 1/3 (d10)
-**Equipment:** Longsword, shield, chain mail, holy symbol
-**Stats:** STR 16(+3) DEX 10(+0) CON 14(+2) INT 8(-1) WIS 12(+1) CHA 15(+2)
-**Saves:** STR +3, DEX +0, CON +2, INT -1, WIS +3*, CHA +4* (* = proficient)
 
-**[PC] Lira Thistledown — Halfling Ranger, Level 3**
-**HP:** 25/25 | **AC:** 15 | **Init:** +3 | **Speed:** 25 ft
+**[PC] Lira Thistledown — Ranger, Level 3**
+**HP:** 25/25 | **AC:** 15 | **Init:** +3
 **Resources:** Spell Slots 1st: 2/3
 **Hit Dice:** 2/3 (d10)
-**Equipment:** Longbow, shortsword, studded leather
-**Stats:** STR 10(+0) DEX 16(+3) CON 12(+1) INT 12(+1) WIS 14(+2) CHA 10(+0)
-**Saves:** STR +2*, DEX +5*, CON +1, INT +1, WIS +2, CHA +0 (* = proficient)
 
 **[NPC] Garen — Human Fighter, Level 3**
 **HP:** 22/22 | **AC:** 14 | **Init:** +1

--- a/docs/dm-session-zero.md
+++ b/docs/dm-session-zero.md
@@ -243,7 +243,7 @@ If the player chooses to create new:
      best fit the chosen class — explain this as: "I'll place the Standard Array numbers (15, 14, 13, 12, 10, 8)
      where they make the most sense for your class").
    - **[BEGINNER]** Recommend Standard Array or optimized preset: "Standard Array is the easiest — I'll assign a set of scores (15, 14, 13, 12, 10, 8) to your stats in a way that fits your class. Want to go with that?"
-   - If Rolled: ask whether the player or the AI rolls; show each roll and final assignment.
+   - If Rolled: default to 4d6 drop lowest (standard 5e method). If the player prefers another method (3d6 straight, 2d6+6, etc.), accommodate it. Ask whether the player or the AI rolls; show each roll and final assignment.
    - Confirm final scores and modifiers with the player.
 
 7. **Variant Human / Origin Feat (Version-Dependent)**
@@ -455,13 +455,9 @@ Before starting Chapter One, output a concise summary:
 Then proceed to Chapter One with the usual structured response format (header, scene, choices, compact stat block).
 
 **Before starting Chapter One, lock the Campaign Constants:**
-Fill in the CAMPAIGN CONSTANTS block with the values confirmed during Session Zero:
-- **Themes:** from Phase 1
-- **Tone:** from Phase 1
-- **Hard Limits:** from Phase 1
-- **Setting:** from Phase 1
-- **Primary Inspirations:** from Phase 1
-- **Ruleset:** from Phase 1
+Fill in the CAMPAIGN CONSTANTS block with the values confirmed during Session Zero.
+Lock these fields: **Themes**, **Tone**, **Hard Limits**, **Setting**, **Primary Inspirations**, **Ruleset**.
+Source all values from Phase 1 discussions.
 
 State them explicitly in a brief meta note before the first chapter response, then never reference them again unless a drift check fires:
 > *(( Campaign locked: [Themes], [Tone], [Setting]. Hard limits: [Limits]. Inspirations: [Titles]. Starting Chapter One. ))*


### PR DESCRIPTION
Fixes across dm-core-rules.md, dm-campaign-ops.md, dm-session-zero.md, and README.md:

- #1: Strip Race/Speed/Equipment/Stats/Saves from Examples 4b and 10 stat blocks
- #2: Fix "Goblin attack" → "Bandit Archer attack" in Example 8b
- #3: Fix Bard level 5 redundant Font of Inspiration listing
- #4: Add instant death rule in Death Saves section
- #5: Add Solo Death Protocol with recovery options for solo PC death
- #6: Add 4d6-drop-lowest as default rolled ability score method
- #7: Add interrupted rest rules
- #9: Fix Monk level 9 to "vertical surfaces and liquids" (not +15 ft)
- #10: Replace Thieves' Cant with Elvish in Kael Varyn example
- #11: Fix ritual casting rules (Bard known vs prepared, Warlock Book of Ancient Secrets)
- #12: Change "Human" to "Variant Human" for Kael Varyn
- #19: Add inline rest fallback with Hit Dice mechanics in combat section
- #20: Add inline companion replacement summary
- #21: Add Campaign Constants field list in Session Zero Phase 6
- #22: Fix "12 worked examples" → "13 worked examples" in README

Closes #13