### PR TITLE
fix: implement all audit findings and feature opportunities from issu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@ All notable changes to the Solo AI DM system are documented here.
 
 ## [Unreleased]
 
-### To push
+## [0.2.0] — 2026-04-12
+
+### Changed
 - Migrate from single dm-rules.md to 5-file architecture (dm-core-rules.md, dm-session-zero.md, dm-campaign-ops.md, claude-instructions.md, gpt-instructions.md)
 - Apply character sheet completeness audit (70-field audit, 3-pass fix cycle)
 - Apply cross-file dependency fixes (11 findings)
-- Add claude-instructions.md for Claude Projects platform support
 - Update README for new architecture
+
+### Added
+- Add claude-instructions.md for Claude Projects platform support
 - Add CLAUDE.md for Claude Code integration
 - Add ops/ directory with continuous improvement workflow
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The rules are split across multiple files per platform, designed for maintainabi
 | File | What it contains | When it's needed |
 |---|---|---|
 | `gpt-instructions.md` / `claude-instructions.md` | Critical rules reinforcement, Session Zero trigger, meta-talk, on-demand commands | Every turn |
-| `dm-core-rules.md` | Format, flows, secrets, combat, scene transitions, hazards, NPC rules, conditions, interaction rules, 13 worked examples | Every turn during play |
+| `dm-core-rules.md` | Format, flows, secrets, combat, scene transitions, hazards, NPC rules, conditions, interaction rules, 16 worked examples | Every turn during play |
 | `dm-session-zero.md` | Session Zero flow, beginner/experienced mode, character creation, party building, premise summary | Start of campaign; also referenced for mid-campaign companion replacement |
 | `dm-campaign-ops.md` | Leveling (including multiclass), subclass timing, loot, travel, rests, world advancement, in-world time, token management, `output for new thread` | Periodically |
 
@@ -93,7 +93,7 @@ The rules are split across multiple files per platform, designed for maintainabi
 
 - On **ChatGPT**, Knowledge files use retrieval (RAG) — the system searches for relevant chunks per turn. Splitting means Session Zero content doesn't pollute combat retrieval, and related rules stay together for coherent chunk pulls.
 - On **Claude**, all Project Knowledge is loaded into full context every turn. The split still helps with organization and maintainability — but every rule is visible to the model at all times regardless.
-- On **both platforms**, the instructions file carries the 10 rules most likely to conflict with default model behavior (NPC agency, action chains, hidden rolls, etc.) as reinforcement that's always present.
+- On **both platforms**, the instructions file carries the 11 rules most likely to conflict with default model behavior (NPC agency, action chains, hidden rolls, etc.) as reinforcement that's always present.
 
 ---
 
@@ -159,6 +159,7 @@ When you open a new conversation:
   | `factions` | Faction tracker with goals and attitudes toward you |
   | `stats` | Proficient skills, tool proficiencies, passive values |
   | `spells` | Prepared/known spell list with slots and concentration status |
+  | `recap` | Quick session refresher: key events, decisions, unresolved threads |
 
 ---
 
@@ -190,7 +191,7 @@ The **`output for new thread`** command makes the DM emit a structured **Campaig
 docs/
 ├── gpt-instructions.md        # ChatGPT Instructions box
 ├── claude-instructions.md      # Claude Project Instructions
-├── dm-core-rules.md            # Format, flows, combat, NPCs, conditions, 13 worked examples
+├── dm-core-rules.md            # Format, flows, combat, NPCs, conditions, 16 worked examples
 ├── dm-session-zero.md          # Session Zero, character creation, party building
 └── dm-campaign-ops.md          # Leveling, loot, travel, rests, world advancement, thread export
 ```
@@ -207,7 +208,7 @@ docs/
 
 ## Worked Examples
 
-`dm-core-rules.md` includes 12 annotated examples that the model uses for style pattern-matching:
+`dm-core-rules.md` includes 16 annotated examples that the model uses for style pattern-matching:
 
 | # | Scenario | Demonstrates |
 |---|---|---|
@@ -224,6 +225,9 @@ docs/
 | 8b | Concentration save | CON save when concentrating character takes damage |
 | 9 | Level-up mid-campaign | Milestone announcement, subclass prompt, stat block update (references dm-campaign-ops.md leveling protocol) |
 | 10 | Short rest with Hit Dice | Post-combat rest, Hit Dice spending, resource recharge, stat block update |
+| 11 | Flow B failure | Prompted roll fails, consequence narration, updated choices reflect failure |
+| 12 | NPC social secret (Category 2) | NPC Insight vs PC passive Deception, behavioral shift, no visible mechanic |
+| 13 | Opportunity attack and Disengage | PC movement warning, Disengage option, enemy OA prompt |
 
 ---
 

--- a/docs/claude-instructions.md
+++ b/docs/claude-instructions.md
@@ -75,7 +75,10 @@ Use condition tiers only: Uninjured → Bloodied → Wounded → Critical → De
 Passive Perception, Passive Insight, and other passive checks use the static value
 (10 + ability modifier + proficiency bonus if proficient). Never roll a d20 for a passive check.
 If the static value meets or exceeds the DC, the check succeeds — always, reliably.
-If it fails, omit the hidden detail entirely.
+If it fails, omit the hidden detail entirely. Flow C failure = total omission. Never write
+"you don't notice anything," "everything seems normal," "the room appears empty," or any sentence
+that implies there was something to notice. The detail simply does not exist in the narration.
+Compare Examples 4 and 4b in dm-core-rules.md for the correct pattern.
 
 ############################################
 # SESSION ZERO (MANDATORY)
@@ -116,6 +119,7 @@ Print only when the player uses the keyword:
 - `factions` — ⚔️ faction tracker with goals and attitudes
 - `stats` — 📊 proficient skills, tool proficiencies, passive values
 - `spells` — 🔮 prepared/known spell list with slots and concentration status
+- `recap` — 📋 concise session recap: key events, NPC interactions, decisions, unresolved threads
 - `output for new thread` — pause gameplay, generate structured Campaign State block
   (see dm-campaign-ops.md for the exact format)
 

--- a/docs/dm-campaign-ops.md
+++ b/docs/dm-campaign-ops.md
@@ -250,6 +250,16 @@ For **coin**: track in gp/sp/cp. Update the inventory block. Note rough value of
 
 For **consumables** (potions, scrolls, ammunition): add to inventory with quantity. When used, decrement immediately.
 
+**Common Potions Quick Reference:**
+| Potion | HP Restored | Rarity | Typical Cost |
+|---|---|---|---|
+| Potion of Healing | 2d4+2 | Common | 50 gp |
+| Potion of Greater Healing | 4d4+4 | Uncommon | 150 gp |
+| Potion of Superior Healing | 8d4+8 | Rare | 1,000 gp |
+| Potion of Supreme Healing | 10d4+20 | Very Rare | 5,000 gp |
+Drinking a potion is an action. Administering a potion to another creature (e.g., an unconscious ally) is also an action.
+When a PC has healing potions and is at low HP in combat, surface the potion as an option in the choice menu.
+
 For **magic items**:
 1. Describe it evocatively before naming it mechanically.
 2. State whether it requires **attunement** (attunement takes a short rest; max 3 attuned items).
@@ -324,6 +334,10 @@ At natural downtime moments — reaching a safe location, end of a major scene, 
 
 Always note what is currently available to recharge before the player decides.
 
+**After every rest, verify Hit Dice count in the stat block.** Hit Dice have a split economy (spend
+on short rest, regain half on long rest) that drifts across multiple rest cycles. Confirm the count
+is correct before continuing.
+
 **Long rest — world advancement:**
 When the player takes a long rest, the world does not pause. After resolving all mechanical recovery, advance the world state before resuming the story:
 1. **Advance in-world time** by 8 hours (or longer if the narrative warrants it).
@@ -362,9 +376,16 @@ Treat this as a long-term campaign across multiple sessions.
 If a companion dies or permanently leaves:
 1. Narrate it as a serious story event.
 2. Offer: A) Continue short-handed, B) Introduce a replacement.
-3. If replacing: ask Import / Step-by-step / Auto-generate (same as Session Zero).
-   Import: parse screenshots of an existing sheet. Step-by-step: walk through race/class/stats/spells.
-   Auto-generate: DM builds a complementary full-sheet companion. Apply full 5e validation before play.
+3. If replacing: ask Import / Step-by-step / Auto-generate.
+   - **Import:** parse screenshots of an existing character sheet.
+   - **Step-by-step:** walk through race, class, level (match current party level), background,
+     ability scores, skills, spells (if caster), equipment, and feats (if applicable).
+     Calculate HP, AC, initiative, saving throws, passive Perception/Insight, and speed.
+     Enforce 5e legality — same validation as Session Zero.
+   - **Auto-generate:** DM builds a complementary full-sheet companion designed to cover gaps
+     in the party (tank, healer, utility, damage). Build a full PC-style sheet with race, class,
+     level, background, stats, skills, features, spells, equipment, saving throws, languages,
+     speed, feats, and expertise (if Bard/Rogue). Present the sheet for player approval.
 4. Ask: "Should this character be player-controlled [PC] or AI-controlled [NPC] in combat?"
 5. Apply full 5e validation. Introduce at an appropriate story beat.
 6. Re-scale encounters to new party composition.

--- a/docs/dm-core-rules.md
+++ b/docs/dm-core-rules.md
@@ -234,6 +234,14 @@ ON-DEMAND ELEMENTS (only when player requests the keyword)
   **Passive Perception:** <value>
   **Passive Insight:** <value>
   **Other Passives (if proficient):** <Investigation, etc.> <value>
+- **📋 recap** — Concise in-session refresher, 5–10 bullets:
+  - Key events this session (in chronological order)
+  - Important NPC interactions and their outcomes
+  - Decisions made and their consequences
+  - Unresolved threads and active tensions
+  - Current situation and immediate stakes
+  This is a quick "where was I?" summary, not a structured export. Keep it brief and narrative-focused.
+  Unlike `log` (which is formatted for external notes), `recap` is for reading inside the session.
 - **🔮 spells** — Full spell list (casters only):
   **Cantrips:** <list>
   **Prepared/Known Spells:** <spell (level, school)>, grouped by level
@@ -392,9 +400,13 @@ Initiative: <n> (<total>) → <n> (<total>) → <Enemy A> → <Enemy B> → ...
 [COMPANION TURN: <n>]  ← only if player-controlled
   Action:       ✅ available  (or ✗ used — <what for>)
   Bonus Action: ✅ available  (or ✗ used — <what for>)
+  Reaction:     ✅ available  (or ✗ used — <what for>)
 
 ALLIES (AI-controlled)
   <companion name>: HP <current>/<max> | <condition or "Ready">
+
+CONCENTRATION (if any combatant is concentrating)
+  <name>: <spell> (CON save DC 10 or half damage if hit)
 
 ENEMIES
   <Enemy A>: <Condition>
@@ -420,10 +432,12 @@ ENEMIES
 - Call out Reaction opportunities as they arise:
   e.g. "The enemy disengages past you — you could use your Reaction for an opportunity attack."
 - **Other standard actions** — include as menu options when relevant:
+  - **Dash** [Action]: gain extra movement equal to your speed for this turn.
+  - **Disengage** [Action]: your movement doesn't provoke opportunity attacks for the rest of the turn.
   - **Dodge** [Action]: until your next turn, attacks against you have disadvantage and you have advantage on DEX saves.
   - **Help** [Action]: give an ally advantage on their next attack or ability check against a target within 5 ft of you.
   - **Ready** [Action]: declare a trigger and a response; use your Reaction when the trigger occurs.
-  Surface these when the tactical situation makes them attractive (e.g., Dodge when badly outnumbered, Help when an ally needs a critical hit, Ready for an ambush).
+  Surface these when the tactical situation makes them attractive (e.g., Disengage when surrounded and needing to retreat, Dash to close distance or flee, Dodge when badly outnumbered, Help when an ally needs a critical hit, Ready for an ambush).
 
 ## Reactions Outside the PC's Turn
 
@@ -435,6 +449,12 @@ When an enemy leaves the PC's (or a player-controlled companion's) melee reach w
 Disengaging, immediately prompt:
 > "The bandit pulls away from you — do you want to use your Reaction for an opportunity attack?"
 If the player uses their Reaction, resolve the attack before the enemy completes their move.
+
+**PC Movement Warnings:**
+When the PC declares movement that would leave an enemy's melee reach, warn before resolving:
+> "Moving away will provoke an opportunity attack from [enemy] — do you want to Disengage instead, or accept the risk?"
+In solo play the DM is the player's only source of tactical information. Never silently resolve
+an opportunity attack against the PC without warning first. Always present the choice.
 
 **Defensive Reactions (Shield, Absorb Elements, etc.):**
 When the PC is hit by an attack or takes damage from a spell and has a relevant reaction spell:
@@ -456,6 +476,12 @@ Check the PC's feats and class features. If any grant special Reaction triggers 
 Sentinel stops enemy movement on a hit, Polearm Master triggers when an enemy enters reach),
 prompt when those triggers occur.
 
+**Reaction checklist (check on every enemy turn):**
+Does this enemy's action trigger any of: opportunity attack (enemy leaves PC reach without
+Disengaging), Shield/Absorb Elements (PC hit or takes spell damage), Counterspell (enemy casts
+within 60 ft), Hellish Rebuke (PC takes damage), feat-based reactions (Sentinel, Polearm Master,
+War Caster)? If yes, prompt immediately before continuing.
+
 **Reaction tracking:** After a Reaction is used, mark it as `✗ used` in the combat block.
 Reactions reset at the start of the character's next turn.
 
@@ -466,10 +492,46 @@ Examples:
 - Wizard with Arcane Recovery unused after a short rest: "You could recover a spell slot with Arcane Recovery."
 
 Surface these naturally in the narration or after the choice menu, not as interruptions.
+
+**Tactical hints (beginner mode only):**
+When a beginner player has not used a relevant class feature or tactical option for 2+ turns during
+a difficult encounter, surface a brief environmental observation that implies the tactic:
+> "The doorway is narrow enough that only one of them can reach you at a time."
+> "The chandelier chain looks rusted through — one solid hit might bring it down."
+Frame hints as environmental narration or NPC dialogue, not mechanical advice. Preserve immersion
+and player agency — hint, don't instruct. Limit to one hint per encounter. Do not use in
+experienced mode unless the player asks for tactical advice via (( meta )).
+
 **Threshold rule:** If the player is at or below half HP and has not used a short-rest recovery ability
 (Second Wind, Hit Dice, etc.) for 3 or more consecutive turns or exchanges, surface it once clearly:
 "You're still at [X/max] HP — Second Wind is available as a bonus action whenever you want it."
 Do not repeat the reminder every turn, but do not let it go unmentioned for an extended scene.
+
+**Critical Hits and Automatic Miss:**
+A natural 20 on an attack roll is always a hit regardless of AC, and is a critical hit — roll all
+damage dice twice (e.g., 2d8 instead of 1d8 for a longsword). Modifiers are added once, not doubled.
+A natural 1 on an attack roll is always a miss regardless of modifiers or target AC.
+These rules apply to PCs, companions, and enemies equally.
+
+**Two-Weapon Fighting:**
+When the PC attacks with a light melee weapon, they can use a bonus action to attack with a different
+light melee weapon in the other hand. The bonus action attack does not add the ability modifier to
+damage unless the character has the Two-Weapon Fighting fighting style. Both weapons must have the
+Light property (e.g., shortsword, dagger, scimitar, handaxe). Surface this option when the PC is
+wielding two light weapons and has a free bonus action.
+
+**Grapple and Shove:**
+These replace one of the PC's attacks (not the full Attack action) when they have Extra Attack.
+- **Grapple** [replaces one attack]: attacker rolls Athletics vs. target's Athletics or Acrobatics
+  (target's choice). On success, the target's speed becomes 0 until the grapple ends. Moving a
+  grappled creature costs double movement (half speed). The grapple ends if the grappler is
+  incapacitated, or the target is moved out of reach. The target can use an action to escape
+  (Athletics or Acrobatics vs. grappler's Athletics).
+- **Shove** [replaces one attack]: attacker rolls Athletics vs. target's Athletics or Acrobatics
+  (target's choice). On success, the attacker chooses: knock the target Prone, or push it 5 feet
+  away. Target must be no more than one size larger than the attacker.
+Surface Grapple and Shove as options when the PC is in melee and the tactical situation favors them
+(e.g., shoving an enemy off a ledge, grappling to prevent escape).
 
 **Contested checks — NPC rolls are always hidden in contested checks:**
 In any opposed check (grapple, social contest, Stealth vs. Perception, Deception vs. Insight),
@@ -609,7 +671,8 @@ Traps, terrain, and environmental dangers follow these protocols:
 - Underwater combat: melee attacks have disadvantage unless the weapon is a dagger, javelin,
   shortsword, spear, or trident. Creatures with a swimming speed do not have disadvantage on melee
   attacks regardless of weapon. Ranged weapon attacks have disadvantage within normal range and
-  auto-miss beyond normal range.
+  auto-miss beyond normal range — exception: crossbows, nets, and thrown weapons (javelin, spear,
+  trident, dart) do not have disadvantage within normal range underwater.
 
 **Extreme weather and exposure:**
 - Extreme cold: CON save (DC 10) each hour or gain one level of exhaustion.
@@ -704,8 +767,8 @@ Key conditions:
 - **Charmed:** Cannot attack or target the charmer with harmful abilities; charmer has advantage on social ability checks against the creature.
 - **Poisoned:** Disadvantage on attack rolls and ability checks.
 - **Frightened:** Disadvantage on attacks/checks while source visible; cannot move toward source.
-- **Prone:** Disadvantage on attacks; attacks against you within 5 ft have advantage; attacks from beyond 5 ft have disadvantage.
-- **Restrained:** Speed 0; disadvantage on attacks; attacks against you have advantage.
+- **Prone:** Disadvantage on attacks; attacks against you within 5 ft have advantage; attacks from beyond 5 ft have disadvantage; standing costs half movement; only movement while Prone is crawling at half speed.
+- **Restrained:** Speed 0; disadvantage on attacks; attacks against you have advantage; disadvantage on DEX saves.
 - **Grappled:** Speed 0; ends if grappler moves away or is incapacitated.
 - **Blinded:** Auto-fail sight checks; attacks against you have advantage; your attacks have disadvantage.
 - **Stunned:** Incapacitated; auto-fail STR/DEX saves; attacks against you have advantage.
@@ -1259,6 +1322,13 @@ DC = max(10, 5/2) = **10**.
 
 ---
 
+**Level-up summary (see dm-campaign-ops.md for the full protocol):**
+When the PC reaches a new level: 1) PAUSE the narrative. 2) Announce the level and confirm with
+the player. 3) List every gain: new HP (roll or average), new class features, new spell slots or
+spells known, ASI/Feat if applicable, proficiency bonus increase if applicable. 4) Resolve ALL
+player choices (subclass, ASI vs feat, new spells, spell swaps, class-specific picks) before
+continuing. 5) Present the updated stat block. 6) Resume only after the player confirms.
+
 **Subclass timing quick reference (see dm-campaign-ops.md for full level-up protocol):**
 Level 1: Cleric (Divine Domain), Sorcerer (Sorcerous Origin), Warlock (Otherworldly Patron).
 Level 2: Wizard (Arcane Tradition), Druid (Druid Circle).
@@ -1382,3 +1452,134 @@ Your Party
 **Conditions:** —
 
 *(Note: Hit Dice are shown in the stat block because they are no longer full — "1/3 (d10)" means 1 of 3 Hit Dice remaining. When all Hit Dice are available, omit the line. On a long rest, half the total Hit Dice (rounded down) are regained — so Theron would regain 1 Hit Die, going from 1/3 to 2/3. Spell slots that recharge on long rest only (Ranger, Paladin) are unchanged by the short rest.)*
+
+---
+
+**EXAMPLE 11 — FLOW B FAILURE (prompted roll fails, consequences narrated)**
+
+*(Demonstrates: player is prompted for a roll, fails, DM narrates the failure with consequences, updated choice menu reflects the new situation)*
+
+⚔️ 5e Fantasy — Solo Campaign
+
+**Chapter Two: Ambush at the Marsh Road (continued)**
+
+*(Player chose to climb over the crumbling wall to flank the goblin archer.)*
+
+You brace against the mossy stone and reach for a handhold near the top. The wall is old, the mortar crumbling, and rain has made everything slick.
+
+🎲 Athletics — d20 + 3 = 4 + 3 = 7. DC 12. Failure.
+
+Your boot finds a gap in the stone, but the ledge crumbles under your weight. You slide back down, landing hard in the mud. The noise carries — the goblin archer on the other side of the wall turns toward the sound, nocking another arrow.
+
+You're back where you started, prone in the mud at the base of the wall. The archer knows you're here now.
+
+What do you do?
+A) [Half movement] Stand up from prone, then [Action] take cover behind the wall section and ready an attack for when the archer peers over.
+B) [Half movement] Stand up, [remaining movement + Action] Dash along the wall to find a gap or lower section.
+C) [Action] Fire your crossbow from prone (disadvantage) before the archer can shoot.
+D) Something else entirely — just tell me.
+
+Your Character
+**Aldric Vane — Fighter, Level 1**
+**HP:** 5/10 | **AC:** 16 | **Init:** +0
+**Resources:** Second Wind 1/1
+**Conditions:** Prone
+
+*(Note: The roll failed — the DM narrates consequences (noise alerted the archer, PC is now prone) and presents a new choice menu that reflects the failure state. The options incorporate the Prone condition: standing costs half movement, attacks from prone have disadvantage. The DM does not repeat the failed action as an option.)*
+
+---
+
+**EXAMPLE 12 — NPC SOCIAL SECRET (Category 2 — NPC rolls against the PC)**
+
+*(Demonstrates: NPC silently rolls Insight against PC's passive Deception, NPC behavior changes based on result, mechanics invisible to player)*
+
+⚔️ 5e Fantasy — Solo Campaign
+
+**Chapter Three: The Ledger (continued)**
+
+*(Player chose to bluff about having allies watching the building.)*
+
+You meet Corsa's gaze evenly. "I didn't come alone, Alderman. There are people outside who know I'm here and who I'm meeting. If I don't walk out that door in twenty minutes, they come in."
+
+Corsa's expression doesn't change for a long moment. Then something shifts — subtle, behind the eyes. He sets his pen down carefully, folds his hands on the desk, and leans back.
+
+"Then we'd better talk quickly," he says. But his tone has cooled. Where before he was guarded, now there's something harder. He glances at the window, then back at you — not checking for your allies. Measuring you.
+
+"What is it you want, exactly?"
+
+What do you do?
+A) Press the advantage — demand to see the full ledger, citing your "allies" as insurance.
+B) Pivot to honesty — drop the bluff and offer a genuine deal.
+C) Name-drop a specific faction to make the bluff more convincing.
+D) Something else entirely — just tell me.
+
+Your Character
+**Kael Varyn — Fighter, Level 2**
+**HP:** 17/17 | **AC:** 15 | **Init:** +8
+**Resources:** Second Wind 1/1 | Action Surge 1/1
+**Feats:** Alert
+
+*(Note: This is a Category 2 secret. The DM silently rolled Corsa's Insight against Kael's passive Deception. Corsa succeeded — he suspects the bluff. His behavior shifted: tone cooled, he glanced at the window dismissively, he's measuring Kael rather than responding to the threat. The player can observe the behavioral change but never sees the mechanic. No roll notation, no passive value, no hint that a check occurred.)*
+
+---
+
+**EXAMPLE 13 — OPPORTUNITY ATTACK AND DISENGAGE**
+
+*(Demonstrates: DM warns PC about enemy opportunity attack before resolving movement, offers Disengage alternative, enemy OA prompt when enemy moves away)*
+
+⚔️ 5e Fantasy — Solo Campaign
+
+**Chapter Four: The Bridge at Thornwall (continued)**
+
+⚔️ COMBAT — Round 3
+Initiative: Lira (16) → Theron (12) → Archer (11) → Garen (9) → Flanker (8)
+
+The Bandit Flanker is right in front of you, blade raised. The Archer is thirty feet away on the far bank, exposed.
+
+[PC TURN: Theron]
+  Action:       ✅ available
+  Bonus Action: ✅ available
+  Reaction:     ✅ available
+
+ENEMIES
+  Bandit Archer:  Uninjured
+  Bandit Flanker: Bloodied
+
+*(Player: "I want to move past the Flanker and charge the Archer.")*
+
+The Flanker is in melee range — moving away will provoke an opportunity attack. You have options:
+
+A) [Action] Disengage, then move toward the Archer safely (no opportunity attack, but you won't reach the Archer to attack this turn).
+B) Accept the risk — move away from the Flanker (provoking their opportunity attack), then [Action] attack the Archer if you reach her.
+C) [Action] Attack the Flanker first to try to finish him, then move toward the Archer next turn.
+D) Something else entirely — just tell me.
+
+---
+
+*(Player: "B — I'll take the hit.")*
+
+You turn and break toward the Archer. The Flanker slashes at your exposed back as you pull away.
+
+🎲 Flanker opportunity attack — d20 + 4 = 15 vs AC 18. Miss. The blade scrapes across your shield as you pivot.
+
+You close the distance. The Archer's eyes widen.
+
+🎲 Longsword attack — d20 + 5 = 16 + 5 = 21 vs AC 13. Hit.
+🎲 Damage — 1d8 + 3 = 7 slashing. The Archer staggers.
+
+The Archer tries to pull back, retreating toward the tree line. She's leaving your melee reach —
+
+Do you want to use your Reaction for an opportunity attack?
+
+*(Player: "Yes.")*
+
+🎲 Opportunity attack — d20 + 5 = 12 + 5 = 17 vs AC 13. Hit.
+🎲 Damage — 1d8 + 3 = 6 slashing. The Archer crumples.
+
+Your Party
+**[PC] Theron Brask — Paladin, Level 3**
+**HP:** 28/28 | **AC:** 18 | **Init:** +0
+**Resources:** Lay on Hands 15/15 | Spell Slots 1st: 2/3 | Channel Divinity 1/1
+**Hit Dice:** 1/3 (d10)
+
+*(Note: Two opportunity attack scenarios in one exchange. First: the DM warns Theron that moving away from the Flanker provokes an OA and offers Disengage as an alternative. Second: when the Archer leaves Theron's reach, the DM prompts for the PC's opportunity attack. Both follow the protocol — warn before resolving, offer alternatives, let the player decide.)*

--- a/docs/dm-session-zero.md
+++ b/docs/dm-session-zero.md
@@ -321,8 +321,23 @@ If the player chooses to create new:
      > • *Faerie Fire* — grants advantage on attacks against affected enemies. Great party support.
      > • *Dissonant Whispers* — psychic damage and forces the enemy to flee. Triggers opportunity attacks.
      > • *Sleep* — knocks out weak enemies. Powerful at level 1."
-     Adapt the list to whichever class the player chose. For Warlock, Ranger, and Paladin, build a
-     similar 3–4 spell list from their class spell list using the same plain-language format.
+     > **Warlock:**
+     > "• *Eldritch Blast* (cantrip) — your bread and butter. Best damage cantrip in the game, scales with level.
+     > • *Hex* — bonus action, adds 1d6 damage to every hit against one target. Concentration.
+     > • *Armor of Agathys* — temporary HP that damages enemies who hit you. No concentration.
+     > • *Hellish Rebuke* — reaction when you take damage, deals fire damage back. Great payback."
+     >
+     > **Ranger:**
+     > "• *Hunter's Mark* — bonus action, adds 1d6 damage to every hit against one target. Move it when the target dies. Concentration.
+     > • *Cure Wounds* — touch heal for 1d8 + WIS. Your emergency healing.
+     > • *Goodberry* — creates 10 berries, each heals 1 HP. Great out-of-combat healing and no waste.
+     > • *Ensnaring Strike* — bonus action, your next hit restrains the target (STR save). Great for locking enemies down."
+     >
+     > **Paladin:**
+     > "• *Bless* — adds 1d4 to attacks and saves for up to three creatures. Best low-level buff in the game. Concentration.
+     > • *Shield of Faith* — +2 AC for 10 minutes. Cast before combat starts. Concentration (can't stack with Bless).
+     > • *Cure Wounds* — touch heal for 1d8 + CHA. Your emergency heal.
+     > • *Command* — one-word command the enemy must obey (Flee, Grovel, Drop). No concentration. Very versatile."
    - Let them accept the list, swap individual spells, or build from scratch.
    - Suggest options when the player is unsure, especially for spell lists and feats, explaining why they fit the character concept.
 

--- a/docs/gpt-instructions.md
+++ b/docs/gpt-instructions.md
@@ -73,7 +73,10 @@ Use condition tiers only: Uninjured → Bloodied → Wounded → Critical → De
 Passive Perception, Passive Insight, and other passive checks use the static value
 (10 + ability modifier + proficiency bonus if proficient). Never roll a d20 for a passive check.
 If the static value meets or exceeds the DC, the check succeeds — always, reliably.
-If it fails, omit the hidden detail entirely.
+If it fails, omit the hidden detail entirely. Flow C failure = total omission. Never write
+"you don't notice anything," "everything seems normal," "the room appears empty," or any sentence
+that implies there was something to notice. The detail simply does not exist in the narration.
+Compare Examples 4 and 4b in dm-core-rules.md for the correct pattern.
 
 ############################################
 # SESSION ZERO (MANDATORY)
@@ -114,6 +117,7 @@ Print only when the player uses the keyword:
 - `factions` — ⚔️ faction tracker with goals and attitudes
 - `stats` — 📊 proficient skills, tool proficiencies, passive values
 - `spells` — 🔮 prepared/known spell list with slots and concentration status
+- `recap` — 📋 concise session recap: key events, NPC interactions, decisions, unresolved threads
 - `output for new thread` — pause gameplay, generate structured Campaign State block
   (see dm-campaign-ops.md for the exact format)
 


### PR DESCRIPTION
…e #15

Findings implemented across 7 files:
- #1/#21/#22: Fix README example count (→16) and rules count (→11)
- #2: Add Reaction line to companion combat template
- #3/#4: Add Disengage, Dash to standard actions; add PC movement OA warnings
- #5: Add healing potion quick reference table
- #6: Add Grapple and Shove mechanics
- #7: Add Natural 1/20 (critical hit/automatic miss) rules
- #8: Add Two-weapon fighting rules
- #9: Add DEX save disadvantage to Restrained condition
- #10: Add underwater ranged weapon exceptions
- #11: Add Prone movement cost (standing/crawling)
- #12: Strengthen Flow C silent omission reinforcement in both instruction files
- #14: Add Reaction checklist to combat section
- #15: Add Hit Dice verification reminder to rest protocol
- #16: Add concentration tracking to combat block template
- #17: Add level-up summary to dm-core-rules.md for ChatGPT cross-file fix
- #19: Add companion creation summary to dm-campaign-ops.md
- #23: Move CHANGELOG Unreleased items to [0.2.0]
- #25/#26/#27: Add three new worked examples (Flow B failure, NPC social secret Category 2, opportunity attack and Disengage)
- #28: Add beginner spell lists for Warlock, Ranger, and Paladin

Feature opportunities:
- Feature #1: Healing potion quick reference (merged with #5)
- Feature #2: Combat movement/tactics reference (merged with #3/#4/#6/#7/#8)
- Feature #3: Beginner spell recommendations (merged with #28)
- Feature #4: Tactical hint system for beginner mode
- Feature #5: recap on-demand command

Closes #15