### PR TITLE
fix: implement audit findings from 2026-06-27 review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,9 @@ There is no application code — only prompt/instruction documents and documenta
 
 ## Repository structure
 - `docs/` — all game files (rules, instructions, platform configs)
-  - `dm-core-rules.md` — runtime DM behavior (~1,200 lines)
-  - `dm-session-zero.md` — character creation and campaign setup (~470 lines)
-  - `dm-campaign-ops.md` — campaign state, rests, travel, level-up (~395 lines)
+  - `dm-core-rules.md` — runtime DM behavior (~1,630 lines)
+  - `dm-session-zero.md` — character creation and campaign setup (~480 lines)
+  - `dm-campaign-ops.md` — campaign state, rests, travel, level-up (~650 lines)
   - `claude-instructions.md` — Claude Project Instructions field content
   - `gpt-instructions.md` — ChatGPT Custom GPT Instructions box content
 - `ops/` — improvement workflow prompts and audit outputs

--- a/docs/dm-campaign-ops.md
+++ b/docs/dm-campaign-ops.md
@@ -274,6 +274,30 @@ For **magic items**:
 - Offer faction contacts or fences as flavor-appropriate buyers for unusual items.
 
 ############################################
+# SHOPPING AND MERCHANT INTERACTION
+############################################
+
+When the player visits a merchant or market, follow this protocol:
+
+**Presenting available wares:**
+- Present 3–5 items relevant to the current level, setting, and party needs. Do not dump a full item list.
+- Scale availability: small towns carry common gear and basic potions; cities offer uncommon items; black markets or faction contacts may carry rare or unusual stock.
+- Format: **Item** — brief description, price. Example: *Potion of Healing — 2d4+2 HP, 50 gp.*
+
+**Pricing:**
+- Use standard 5e costs as a baseline. Adjust for setting economy (a corrupt merchant-city may mark up; a grateful village may offer discounts).
+- Mundane gear at list price. Potions: Healing 50 gp, Greater Healing 150 gp, Superior Healing 1,000 gp.
+
+**Haggling:**
+- If the player attempts to negotiate price, prompt a Persuasion check (Flow B). Set the DC based on merchant disposition: Friendly DC 10, Neutral DC 15, Unfriendly DC 20.
+- On success: 10–20% discount. On failure: price holds. On a critical failure (nat 1 total): merchant is offended and may refuse to sell.
+- Some items are non-negotiable (rare magic items, faction-controlled stock).
+
+**Inventory update:**
+- Deduct coin and add items immediately. Show both the updated inventory and remaining coin in the response.
+- If the player is buying multiple items, confirm the full list before updating.
+
+############################################
 # TRAVEL AND MOVEMENT
 ############################################
 
@@ -324,8 +348,7 @@ At natural downtime moments — reaching a safe location, end of a major scene, 
 - **Short rest recharges:** Warlock Pact Magic slots, Ki/Discipline Points, Hit Dice spending,
   Second Wind, Action Surge, Bardic Inspiration (Lvl 5+ only; Long Rest before that),
   Channel Divinity, Wild Shape (recharges on short rest).
-  Wizard Arcane Recovery: once per long rest, during a short rest, recover spell slots
-  totaling up to half Wizard level (rounded up), no slot above 5th.
+  Wizard Arcane Recovery: once per long rest, during a short rest, recover spell slots whose combined level totals up to half Wizard level (rounded up), no single slot above 5th.
 - **Long rest recharges:** All spell slots (Warlock slots also recharge here, though they already recharge on short rest), all class resources
   (Rage, Lay on Hands, Sorcery Points, Wild Shape, etc.), HP to full,
   half total Hit Dice (rounded down).
@@ -346,6 +369,13 @@ When the player takes a long rest, the world does not pause. After resolving all
 3. **Narrate one world beat** — a brief sentence or two describing something that happened off-screen.
    This can be ambient (a distant bell, new wanted posters) or consequential (an NPC has moved, a route is now guarded).
 4. **Do not overwhelm** — one beat per rest is enough. Save larger revelations for when the player actively investigates.
+
+**Long rest — prepared spell adjustment:**
+After resolving all mechanical recovery, prompt prepared casters (Wizard, Cleric, Druid, Paladin) to adjust their prepared spell list:
+> "You now have access to your full class spell list for preparation. Want to swap any prepared spells before we continue?"
+Present this before resuming the story. If the player has no changes, acknowledge and move on. If they do, update the spell list immediately and confirm the new prepared list.
+
+Example: "Theron (Paladin) can adjust his prepared spell list — he has access to all Paladin spells up to 2nd level. Any changes, or keeping the same list?"
 
 **Short rest — minimal world advancement:**
 Short rests (1 hour) advance time but rarely trigger faction moves. Use them for:

--- a/docs/dm-core-rules.md
+++ b/docs/dm-core-rules.md
@@ -34,6 +34,11 @@ announcing it. Never acknowledge the drift unless the player raises it via (( me
 
 **Common spell save DCs:** 8 + proficiency bonus + spellcasting ability modifier.
 
+**Natural 20 / Natural 1:**
+- Attack rolls only: natural 20 = critical hit (always hits regardless of AC); natural 1 = always misses regardless of modifiers.
+- Ability checks and saving throws (2014): use the total result — there is no auto-success on nat 20 or auto-fail on nat 1.
+- 2024 rules: natural 20 is an automatic success and natural 1 is an automatic failure on all d20 Tests (attacks, ability checks, and saving throws).
+
 **Short rest recharges:** Warlock Pact Magic slots, Ki/Discipline Points, Hit Dice spending,
 Second Wind, Action Surge, Bardic Inspiration (Lvl 5+), Channel Divinity, Wild Shape.
 
@@ -103,6 +108,7 @@ Examples: Passive Perception while walking, Passive Insight triggered by suspici
   Do NOT roll a d20 — passive checks use the static value per standard 5e rules.
 - Compare the passive value against the DC silently. Narrate only what the character perceives if the check succeeds.
 - If it fails, omit the hidden detail entirely. The player never knows what was missed.
+  **Flow C failure = total omission.** Do not write "you don't notice anything," "the room seems quiet," "everything appears normal," "something feels off," "you can't quite place it," or any phrasing that implies there was a detail to find. The hidden element simply does not exist in the narration.
 - See SECRETS HANDLING below for the reveal format.
 - **Passive values are DM-side only — do not show them in the stat block.** Calculate from the
   character sheet and track internally:
@@ -154,13 +160,13 @@ Resources reference — track whichever apply at current level, update counts af
   + Weapon Mastery: track which weapon types have mastery active (no uses — always on)
 - Monk: Ki Points <X>/<Monk level> (called Discipline Points in 2024) | Martial Arts (auto) | Unarmored Defense (auto)
   Flurry of Blows, Patient Defense, Step of the Wind all cost 1 Ki (Lvl 2+). Stunning Strike costs 1 Ki (Lvl 5+).
-- Paladin: Spell Slots by level | Lay on Hands <X>/<max> | Divine Smite (auto) | Channel Divinity 1/1 (Lvl 3+)
+- Paladin: Spell Slots by level | Lay on Hands <X>/<max> | Divine Smite (2014: on hit, no action economy cost — expend a spell slot when you hit with a melee weapon attack; 2024: bonus action spell) | Channel Divinity 1/1 (Lvl 3+)
 - Ranger: Spell Slots by level | Favored Enemy/Foe (auto) | Natural Explorer (auto)
   2024: Weapon Mastery at level 1 (same as Fighter).
 - Rogue: Sneak Attack (auto) | Cunning Action (auto, Lvl 2+)
 - Wizard/Sorcerer: Spell Slots by level | Arcane Recovery 1/1 (Wizard) | Font of Magic (Sorcerer, Lvl 2+): Sorcery Points <X>/<Sorcerer level> | Metamagic (Sorcerer, Lvl 3+)
 - Cleric/Druid: Spell Slots by level | Channel Divinity 1/1 (Lvl 2+) | Wild Shape 2/2 (Druid, Lvl 2+)
-- Warlock: Spell Slots <X>/<X> (Short Rest) — 1 slot at Lvl 1, 2 at Lvl 2+ | Eldritch Invocations (auto)
+- Warlock: Spell Slots <X>/<X> (Short Rest) — 1 slot at Lvl 1, 2 at Lvl 2–10, 3 at Lvl 11–16, 4 at Lvl 17+ | Eldritch Invocations (auto)
 If a resource is expended, show 0/max until recharged.
 
 **Spell management (for casters and spellcasting companions):**
@@ -181,13 +187,14 @@ When a spell is cast, always state:
 - Only one concentration spell can be active at a time.
 - If a second concentration spell is cast, the first ends automatically — narrate this.
 - Show concentration status in the Conditions line: `**Conditions:** Concentrating: Hunter's Mark`
+- When no concentration spell is active, omit the Conditions line entirely — same omit-when-default pattern as Hit Dice and Inspiration. Do NOT write `Concentrating: None` or `Conditions: —`.
 - When the character takes damage while concentrating, prompt a CON save immediately.
   DC = 10 or half the damage taken, whichever is higher.
 - Concentration also breaks if the character is incapacitated.
 
 **Spell slot recovery:**
 - **Long rest:** all slots restored for all classes (Warlock Pact Magic slots also restore, though they already recharge on short rest).
-- **Short rest:** Warlock restores all Pact Magic slots. Wizard may use Arcane Recovery (once per long rest) to recover slots up to half their Wizard level (rounded up), no slot above 5th.
+- **Short rest:** Warlock restores all Pact Magic slots. Wizard may use Arcane Recovery (once per long rest) to recover spell slots whose combined level totals up to half their Wizard level (rounded up), no single slot above 5th. (A Level 5 Wizard recovers up to 3 combined levels — one 3rd-level slot, or one 2nd + one 1st, etc.)
 
 **Ritual casting:**
 - Spells with the Ritual tag can be cast without using a spell slot by adding 10 minutes to the casting time.
@@ -219,8 +226,22 @@ ON-DEMAND ELEMENTS (only when player requests the keyword)
   **Appearance:** <one-line physical summary: build, hair, eyes, notable features>
   **Hook:** <current secret or leverage>
   Update dispositions to reflect current story state, not how they were introduced.
+
+  *Format example:*
+  **Maris** | Human | Informant, former syndicate courier | Allied | she/her
+  **Appearance:** Small and wiry, early twenties, dark circles under brown eyes, ink-stained fingers
+  **Hook:** Knows the name Velmire's operatives were trying to extract — hasn't shared it yet
+
+  **Alderman Corsa** | Dwarf | Merchant-politician, Thornwall trade licenses | Hostile | he/him
+  **Appearance:** Broad-shouldered, mid-fifties, grey-streaked auburn beard cropped short, spotless green waistcoat
+  **Hook:** His smuggling ledger is in Kael's possession — he wants it back at any cost
+
 - **⚔️ factions** — Faction tracker, one entry per active faction:
   **<Faction Name>** | <Goal> | <Current attitude toward PC> | <One current action or threat>
+
+  *Format example:*
+  **House Velmire** | Control Blackveil district smuggling routes | Hostile | Searching for their missing operatives — will escalate by Day 3
+  **The Chandlers' Guild** | Maintain neutrality and protect trade | Neutral | Unaware of Kael; protective of their district
 - **📊 stats** — Full ability scores, saves, skills, and proficiencies:
   **Race:** <race>
   **Stats:** STR <score>(<mod>) DEX <score>(<mod>) CON <score>(<mod>) INT <score>(<mod>) WIS <score>(<mod>) CHA <score>(<mod>)
@@ -438,6 +459,7 @@ ENEMIES
   - **Help** [Action]: give an ally advantage on their next attack or ability check against a target within 5 ft of you.
   - **Ready** [Action]: declare a trigger and a response; use your Reaction when the trigger occurs.
   Surface these when the tactical situation makes them attractive (e.g., Disengage when surrounded and needing to retreat, Dash to close distance or flee, Dodge when badly outnumbered, Help when an ally needs a critical hit, Ready for an ambush).
+- **Free object interaction (once per turn):** Each turn a character can interact with one object for free — draw or sheathe a weapon, open an unlocked door, pick up an item, hand something to an ally within reach. A second object interaction on the same turn costs an Action. Surface this when a PC wants to switch weapons mid-combat or interact with an object while also attacking.
 
 ## Reactions Outside the PC's Turn
 
@@ -461,6 +483,14 @@ When the PC is hit by an attack or takes damage from a spell and has a relevant 
 > "The bolt hits — you have Shield prepared. Use your Reaction to cast it? (+5 AC, might turn the hit into a miss.)"
 Check the PC's prepared/known spell list before prompting. Only prompt when the reaction
 would be mechanically relevant (e.g., Shield when the attack roll could become a miss).
+
+**Enemy Spell Identification:**
+When an enemy casts a spell, describe only the visible effects in narration — gestures, component materials, the color and shape of the magical effect. Do not name the spell unless:
+- The PC successfully identifies it (see below), or
+- It is unmistakably familiar (e.g., the PC is a caster who knows that spell, or has seen it used before this session).
+
+If the PC has Arcana proficiency, they may use their Reaction to attempt identification (DC 15 + spell level per Xanathar's Guide). Prompt: `"The mage begins casting — want to use your Reaction to try to identify it? (Arcana check.)"` On success, name the spell and its key effect. On failure, describe only what they observe.
+If the PC does not have Arcana proficiency, do not prompt. Let the visual effects inform the player's tactical decisions.
 
 **Counterspell:**
 When an enemy casts a spell within 60 feet of a character who knows Counterspell:
@@ -533,6 +563,16 @@ These replace one of the PC's attacks (not the full Attack action) when they hav
 Surface Grapple and Shove as options when the PC is in melee and the tactical situation favors them
 (e.g., shoving an enemy off a ledge, grappling to prevent escape).
 
+**Hiding in Combat:**
+Any character can Hide as an action. Rogues with Cunning Action can Hide as a bonus action. Hiding requires total cover or heavy obscurement from the target (behind a pillar, in darkness, around a corner — not simply being in dim light or behind a small obstacle).
+
+Protocol:
+- Roll Stealth secretly; compare against each enemy's Passive Perception. Hidden status applies separately for each enemy.
+- If the check succeeds against an enemy: the hider is invisible to that enemy. Attacks from the hider against that enemy have advantage, and the enemy cannot target the hider with attacks that require sight. Hidden status breaks the moment the hider attacks, casts a spell with a visible effect, or is otherwise revealed (moves out of cover into line of sight, makes enough noise, etc.).
+- If the check fails against an enemy: they know the hider's general location and hidden status does not apply.
+- In the narration: do not reveal whether the Stealth roll succeeded to enemies that failed to detect the hider. Let their behavior reflect the outcome (a guard continues their patrol vs. peers toward the shadow).
+- Surface the Hide option in the combat menu when cover or obscurement is available and relevant: `[Bonus Action] Cunning Action: Hide behind the pillar.`
+
 **Contested checks — NPC rolls are always hidden in contested checks:**
 In any opposed check (grapple, social contest, Stealth vs. Perception, Deception vs. Insight),
 show only the player's roll and the outcome. Never display the NPC's roll or their modifier.
@@ -551,7 +591,7 @@ The NPC's result is resolved internally and reflected only in the narrative outc
 5. If the player declares multiple actions, resolve only up to the first check — see PLAYER DECLARATION PROCESSING.
 
 **Rest after combat:** Offer both short and long rest options. State available Hit Dice.
-Short rest: spend Hit Dice to recover HP (roll class hit die + CON mod per die spent). Recharges: Warlock slots, Ki, Second Wind, Action Surge, Channel Divinity, Bardic Inspiration (Lvl 5+).
+Short rest: spend Hit Dice to recover HP (roll class hit die + CON mod per die spent). Recharges: Warlock slots, Ki, Second Wind, Action Surge, Channel Divinity, Wild Shape, Bardic Inspiration (Lvl 5+).
 Long rest: full HP, all spell slots, all class resources restored. Half total Hit Dice (rounded down) regained.
 (Hit die sizes: d6 Sorcerer/Wizard; d8 Bard/Cleric/Druid/Monk/Rogue/Warlock; d10 Fighter/Paladin/Ranger; d12 Barbarian.)
 On long rest: advance in-world time 8 hours, tick one faction/threat clock, narrate one world beat
@@ -638,6 +678,9 @@ to prevent mechanical and narrative discontinuity.
 3. Re-establish the environment if the location has changed or been altered by the previous scene
    (overturned furniture, broken doors, bodies, fires).
 
+**In-world time at scene transitions:**
+At each scene transition, state the current in-world Day and approximate time of day — either woven into the narration ("It's nearing the 10th bell as you step into the corridor") or as an inline note *(Day 2 — late evening)*. This is the primary re-anchoring point for time tracking between rests.
+
 ############################################
 # ENVIRONMENTAL HAZARDS
 ############################################
@@ -654,6 +697,10 @@ Traps, terrain, and environmental dangers follow these protocols:
   Use Flow B: prompt the roll, then resolve.
 - **Damage:** Scale trap damage to level: 1d6–2d6 at levels 1–4, 3d6–4d6 at levels 5–8,
   5d6+ at levels 9+. Adjust for trap severity and setting.
+
+**Climbing and Swimming:**
+- Climbing and swimming cost 1 extra foot of movement per foot moved (effectively halving speed) unless the creature has a climb or swim speed. Difficult terrain on a climb or swim doubles this cost (3 feet of movement per foot moved).
+- Creatures without a swim speed have disadvantage on melee attack rolls while fully submerged (see Drowning below for ranged weapon penalties underwater).
 
 **Falling:**
 - 1d6 bludgeoning damage per 10 feet fallen, to a maximum of 20d6 (200 feet).
@@ -1235,7 +1282,7 @@ ENEMIES
 The Scarred Leader is right in front of you. The Archer is thirty feet north on the bank. The Flanker is closing from the south, not yet in melee.
 
 What do you do?
-A) [Action] Longsword attack on the Scarred Leader. [Bonus Action] Divine Smite if you hit.
+A) [Action] Longsword attack on the Scarred Leader — Divine Smite if you hit (expend a spell slot on hit; no action cost under 2014 rules).
 B) [Action] Longsword attack on the Scarred Leader — save your slots.
 C) [Action] Shove the Scarred Leader toward the bridge edge (contested Athletics).
 D) Something else entirely — just tell me.
@@ -1287,7 +1334,6 @@ Your Party
 **[PC] Theron Brask — Paladin, Level 3**
 **HP:** 28/28 | **AC:** 18 | **Init:** +0
 **Resources:** Lay on Hands 15/15 | Spell Slots 1st: 2/3 | Channel Divinity 1/1
-**Conditions:** Concentrating: *None*
 
 **[PC] Lira Thistledown — Ranger, Level 3**
 **HP:** 25/25 | **AC:** 15 | **Init:** +3
@@ -1297,9 +1343,8 @@ Your Party
 **[NPC] Garen — Human Fighter, Level 3**
 **HP:** 22/22 | **AC:** 14 | **Init:** +1
 **Resources:** Second Wind 1/1 | Action Surge 1/1
-**Conditions:** —
 
-*(Note: Theron and Lira are player-controlled — full stat blocks, separate choice menus. Garen is AI-controlled — compact block, turn narrated by the DM without a menu. Initiative order determines turn sequence, not PC/companion status.)*
+*(Note: Theron and Lira are player-controlled — full stat blocks, separate choice menus. Garen is AI-controlled — compact block, turn narrated by the DM without a menu. Initiative order determines turn sequence, not PC/companion status. Theron and Garen have no active conditions — the Conditions line is omitted entirely per the omit-when-default pattern. Lira's Conditions line is shown because she is actively concentrating.)*
 
 ---
 

--- a/docs/dm-session-zero.md
+++ b/docs/dm-session-zero.md
@@ -83,6 +83,7 @@ ORIGINALITY REQUIREMENTS:
 After themes and inspirations, determine party composition:
 
 - "Do you want to adventure SOLO or with a PARTY?"
+- **[BEGINNER]** Before they answer, add: "If this is your first time, I'd recommend starting solo — one character is much simpler to manage, and you can always add companions later once the rules feel comfortable. That said, a party works great too if you want the company. Solo or party?"
 - If party: "How many total party members (1–4)? Remember the first is your main character."
 
 The FIRST party member is always the player's primary point-of-view character.
@@ -441,6 +442,7 @@ For each additional party member:
 4. **Death, Retirement, and Replacement**
 
 - If a party member dies or permanently leaves:
+  - **Narrate the death with the same weight as a named NPC death (see Named NPC Death in dm-core-rules.md).** Even a companion the player has directed in combat deserves a final beat — a last word, a consequential silence, another character's reaction. Give the player a moment to respond before pivoting to replacement mechanics. Do not rush from "Lira falls" to "want to introduce a new companion?" in the same paragraph.
   - Present this as a serious story event.
   - Offer the player options:
     - Continue short-handed,


### PR DESCRIPTION
## Summary

Implements all actionable findings from the 2026-06-27 audit across all four files. No features — findings only.

### Rules accuracy
- **Example 8 Divine Smite** (1.2/3.1/9.1 — High): Removed `[Bonus Action]` label; Divine Smite has no action economy cost under 2014 rules. Added Paladin resources clarification noting the 2014 vs 2024 difference.
- **Arcane Recovery wording** (3.2): Changed "recover slots" to "recover spell slots whose combined level totals up to…" in both `dm-core-rules.md` and `dm-campaign-ops.md`.
- **Warlock Pact Magic high levels** (3.4): Fixed "2 at Lvl 2+" → "2 at Lvl 2–10, 3 at Lvl 11–16, 4 at Lvl 17+".
- **Wild Shape short rest gap** (from consistency review): Added Wild Shape to the combat-section short rest list, which was the only place it was missing.

### Example 8 stat block fixes
- **Conditions omit-when-default** (1.1/9.1 — Medium): Removed `**Conditions:** Concentrating: *None*` from Theron's block and `**Conditions:** —` from Garen's block. Updated the note to explain the pattern explicitly.

### Clarifications
- **Concentration + omit-if-none ambiguity** (1.3): Added explicit one-liner to the concentration tracking section.
- **Flow C leak phrases** (4.1): Added common phrases to avoid ("something feels off," "the room seems quiet," etc.) to the Flow C failure rule.
- **Nat 20/1 for ability checks** (2.7): Added to the cheat sheet — auto-success/fail applies to attack rolls only under 2014 rules.
- **Free object interaction** (2.4): Added to action economy section.
- **In-world time at scene transitions** (4.4): Added requirement to re-anchor Day/time at each scene transition.

### Coverage additions
- **Hiding in Combat** (2.1 — High): Full protocol added after Grapple/Shove — cover requirements, Stealth vs passive Perception, advantage on first attack, when hidden status breaks.
- **Enemy spell identification** (2.3): Protocol added to the Reactions section — describe effects, prompt Arcana check if proficient, name only if identified.
- **Climbing and swimming movement** (2.5): Brief note added to Environmental Hazards.
- **Shopping and merchant interaction** (2.2): New section added to `dm-campaign-ops.md` — wares presentation, pricing, haggling (Persuasion DC by disposition), inventory update.
- **Long rest spell preparation prompt** (9.3): Added to the long rest world advancement section.
- **npcs and factions format examples** (9.2): Added compact worked examples in the ON-DEMAND ELEMENTS section (using existing Kael/Maris/Corsa cast).
- **Companion death narrative guidance** (2.8): Added to `dm-session-zero.md` Death/Retirement section.
- **Beginner solo nudge** (10.1): Added `[BEGINNER]` prompt at Phase 2 suggesting solo for first-timers.

### Metadata
- **CLAUDE.md line counts** (7.1): Updated to current values (~1,630 / ~480 / ~650).

## Files changed
| File | Changes |
|------|---------|
| `docs/dm-core-rules.md` | 11 edits: cheat sheet, Flow C, concentration, Paladin/Warlock resources, Arcane Recovery, action economy, Hiding in Combat, enemy spell ID, climbing/swimming, scene transitions, Example 8 stat blocks, on-demand examples |
| `docs/dm-campaign-ops.md` | 3 edits: Arcane Recovery wording, new Shopping section, long rest spell prep prompt |
| `docs/dm-session-zero.md` | 2 edits: companion death narrative, beginner solo nudge |
| `CLAUDE.md` | 1 edit: line counts |

## Findings skipped or deferred
- **3.3** (training proficiency formula): Could not locate a "Downtime Activities" section in `dm-campaign-ops.md` — may be a stale audit reference. No content to fix.
- **2.6** (mounted combat): Audit itself flagged as lower priority pending campaign need. Not added.
- **4.2, 4.3, 5.2, 5.3**: Audit explicitly marked "no fix needed."

🤖 Generated with [Claude Code](https://claude.ai/claude-code)