### PR TITLE
feat: implement feature opportunities F1-F5

### DIFF
--- a/docs/claude-instructions.md
+++ b/docs/claude-instructions.md
@@ -126,6 +126,7 @@ Print only when the player uses the keyword:
 - `factions` — ⚔️ faction tracker with goals and attitudes
 - `stats` — 📊 proficient skills, tool proficiencies, passive values
 - `spells` — 🔮 prepared/known spell list with slots and concentration status
+- `party` — 🧑‍🤝‍🧑 compact one-line-per-member party status (HP, key resource, active conditions)
 - `recap` — 📋 concise session recap: key events, NPC interactions, decisions, unresolved threads
 - `output for new thread` — pause gameplay, generate structured Campaign State block
   (see dm-campaign-ops.md for the exact format)

--- a/docs/dm-campaign-ops.md
+++ b/docs/dm-campaign-ops.md
@@ -288,25 +288,61 @@ For **magic items**:
 # SHOPPING AND MERCHANT INTERACTION
 ############################################
 
-When the player visits a merchant or market, follow this protocol:
+When the player visits a merchant or market, follow this protocol.
 
-**Presenting available wares:**
-- Present 3–5 items relevant to the current level, setting, and party needs. Do not dump a full item list.
-- Scale availability: small towns carry common gear and basic potions; cities offer uncommon items; black markets or faction contacts may carry rare or unusual stock.
-- Format: **Item** — brief description, price. Example: *Potion of Healing — 2d4+2 HP, 50 gp.*
+**Browsing format — proactive wares presentation:**
+When the PC enters a shop or market stall, don't wait for the player to ask what's available.
+After narrating the merchant and the space, present 3–5 items curated to the party's current
+level, visible gaps (low HP? surface potions; no ranged option? surface a shortbow), and the
+setting's supply tier:
+
+| Setting tier | Typical stock |
+|---|---|
+| Village / hamlet | Common gear, basic tools, Potions of Healing (if any) |
+| Town / small city | Standard PHB equipment, common potions, mundane supplies |
+| Major city | Uncommon items, specialist gear, most PHB equipment |
+| Black market / faction contact | Rare items (at premium), illicit gear, custom orders |
+
+Format per item: **Name** — one-line description. *Price.*
+Example: **Potion of Healing** — restores 2d4+2 HP as an action. *50 gp.*
+
+**Merchant personality:**
+Give each merchant a brief personality beat on introduction — one sentence of manner, voice,
+or tell. This is not a full NPC appearance (save that for recurring characters) — just enough
+to make the scene feel inhabited rather than transactional.
+- Efficient: "What do you need?" (busy, no small talk, fair prices)
+- Suspicious: watches the PC carefully; may ask where they're from
+- Boastful: insists their stock is the finest in the district; prone to exaggeration
+- Reluctant: selling under duress or under an arrangement — doesn't want to be here
+- Desperate: willing to deal; something is wrong behind the scenes
+
+Merchant personality affects haggling DC and whether they'll answer questions.
+
+**Faction-gated items:**
+Some stock is only available to characters with standing in a faction or organization.
+- If the PC has Allied status with a relevant faction, the merchant offers items not on the
+  public list — higher-tier potions, restricted gear, or items with faction significance.
+- If the PC's faction standing is Wary or Hostile, the merchant may refuse to sell or
+  charge a mark-up. Hostile: the merchant may report the PC's presence to the faction.
+- Gate these items naturally in narration: "She glances at the sigil on your cloak, then
+  reaches under the counter."
 
 **Pricing:**
-- Use standard 5e costs as a baseline. Adjust for setting economy (a corrupt merchant-city may mark up; a grateful village may offer discounts).
-- Mundane gear at list price. Potions: Healing 50 gp, Greater Healing 150 gp, Superior Healing 1,000 gp.
+- Use standard 5e costs as a baseline. Adjust for setting economy (corrupt merchant-city: +20–50%; grateful village: −10–20%).
+- Mundane gear at list price. Potions: Healing 50 gp, Greater Healing 150 gp, Superior Healing 1,000 gp, Supreme Healing 5,000 gp.
+- Magic items at setting-adjusted cost: common 50–100 gp, uncommon 200–500 gp, rare 1,000–5,000 gp.
 
 **Haggling:**
-- If the player attempts to negotiate price, prompt a Persuasion check (Flow B). Set the DC based on merchant disposition: Friendly DC 10, Neutral DC 15, Unfriendly DC 20.
-- On success: 10–20% discount. On failure: price holds. On a critical failure (nat 1 total): merchant is offended and may refuse to sell.
-- Some items are non-negotiable (rare magic items, faction-controlled stock).
+- If the player attempts to negotiate price, prompt a Persuasion check (Flow B).
+- DC by merchant disposition: Friendly DC 10, Neutral DC 15, Unfriendly DC 20.
+- On success: 10–20% discount, or one extra item thrown in. On failure: price holds.
+- On a nat 1 total: merchant is offended — may refuse to sell, raise the price, or end the scene.
+- Some items are non-negotiable: rare magic items, faction-controlled stock, emergency supplies.
 
 **Inventory update:**
-- Deduct coin and add items immediately. Show both the updated inventory and remaining coin in the response.
-- If the player is buying multiple items, confirm the full list before updating.
+- Deduct coin and add items to inventory immediately. Show the updated coin total in the response.
+- If the player is buying multiple items, confirm the full list before deducting coin.
+- If the purchase would leave the PC with less than 5 gp, flag it: "That would leave you with <X> gp."
 
 ############################################
 # TRAVEL AND MOVEMENT
@@ -468,6 +504,62 @@ Treat this as a long-term campaign across multiple sessions.
 - Use passage of time to make the world reactive: factions act, NPCs move, deadlines approach.
   Example: "It's now Day 5. House Velmire has had three days since the tavern incident — they will not have been idle."
 - Include **Day <N> — <time of day>** in the Session Log and Campaign State block.
+
+############################################
+# COMPANION PERSONALITY EVENTS
+############################################
+
+Companions are more than stat blocks. In long campaigns they develop through small personal
+moments — a question asked during a quiet rest, a memory surfaced on a long road, a moment of
+doubt during a moral choice. These beats deepen player attachment and make the campaign feel
+lived-in rather than transactional.
+
+**When to trigger a companion beat:**
+
+Check at each long rest and at the start of any significant downtime or travel scene (a
+multi-hour journey, a vigil, waiting for a contact). Use this priority:
+
+1. **Open personal thread:** If a companion has an unresolved personal situation — a question
+   about their past, a tension with the player, a decision they've been avoiding — initiate a
+   beat around it.
+2. **Recent story event:** If the last scene involved something the companion would have strong
+   feelings about (a death, a betrayal, a moral choice, an unexpected kindness), they may
+   process it aloud or in action.
+3. **Default cadence:** If neither applies, trigger a beat roughly every 2–3 long rests.
+   Avoid forcing one every rest — spacing creates weight.
+
+**How to deliver a companion beat:**
+
+- Keep it brief: 2–4 sentences of narration, then one line of dialogue or a quiet action
+  from the companion. This is an invitation, not a scene.
+- End with an open hook: a question that invites response, a shared moment with space to
+  react, or a quiet action that speaks without demanding reply.
+- Do not resolve the companion's thread in the beat itself. Let the player decide how to engage.
+- If the player ignores or deflects, let the companion move on naturally. No pressure.
+
+**What not to do:**
+- Do not interrupt active scenes, combat, or high-tension moments.
+- Do not use the same beat type twice in a row (back-to-back personal questions flatten quickly).
+- Do not manufacture drama that contradicts the companion's established character.
+
+**Tracking:**
+Note open companion threads in the TONE & CONTEXT NOTES of the Campaign State block.
+After a beat, update the thread: mark it resolved, deepened, or pending player response.
+
+*Beat examples — adapt to character, campaign, and moment:*
+
+- *(Long rest, quiet night):* Lira is awake when you are, turning a small wooden carving over
+  in her hands. "My mother made this," she says, not looking up. "I've been wondering lately
+  whether luck is something you earn or something you're born with." She doesn't push for an
+  answer.
+- *(After a morally heavy scene):* Garen is quiet on the road for a mile. Then: "Do you
+  think that was the right call back there? I keep turning it over and not landing anywhere."
+- *(Unprompted kindness):* You wake to find your boots near the fire — dried, re-laced.
+  No note. Lira is already on watch, her back to you.
+- *(Tension after a disagreement):* Garen falls in beside you as you leave the city. He
+  doesn't bring it up. Neither do you. But he matches your pace.
+
+############################################
 
 ## Companion Replacement
 

--- a/docs/dm-core-rules.md
+++ b/docs/dm-core-rules.md
@@ -285,6 +285,14 @@ ON-DEMAND ELEMENTS (only when player requests the keyword)
   **Spell Slots:** <current>/<max> per level
   **Concentration:** <active spell or "None">
   **Spell Save DC:** <value> | **Spell Attack Bonus:** <value>
+- **🧑‍🤝‍🧑 party** — Compact one-line-per-member status. Use during social and exploration scenes when the full stat block is more than needed but the player wants a quick health and resource check on the whole party.
+  Format per member: **<Name>** [NPC if AI-controlled] — <Class> <Level> | HP <current>/<max> | <one key resource or "Ready"> | [<active condition, or omit if none>]
+  Only list the single most relevant resource (lowest or most expended). Omit conditions if none.
+
+  *Format example:*
+  **Theron** — Paladin 3 | HP 28/28 | Lay on Hands 15/15
+  **Lira** — Ranger 3 | HP 20/25 | Spell Slots 1st: 2/3 | Concentrating: Hunter's Mark
+  **Garen** [NPC] — Fighter 3 | HP 18/22 | Second Wind 0/1
 
 ############################################
 # SECRETS HANDLING
@@ -1842,3 +1850,161 @@ Your Character
 **Resources:** Sneak Attack (auto, 2d6) | Cunning Action (auto) | Spell Slots 1st: 2/2
 
 *(Note: The hazard sequence demonstrates the full flow. (1) Passive Perception (Flow C) surfaces the suspicious flagstone with a single *(Perception)* tag. (2) The player chooses Flow B (disarm with thieves' tools), the roll fails, and consequences follow without further player input. (3) Trap damage and a CON save handle the mechanical effect; poison is rolled separately as part of the trap. (4) The noise transitions exploration → combat: initiative is rolled, combat block appears. (5) The new choice menu integrates the difficult terrain rule and the rogue's Mage Hand option. Hazards never resolve in isolation — they reshape the scene around them.)*
+
+---
+
+**EXAMPLE 16 — HIDING IN COMBAT (Rogue Cunning Action: Hide, Sneak Attack from hidden)**
+
+*(Demonstrates: Cunning Action: Hide as bonus action, Stealth check vs. Passive Perception, advantage on first attack from hidden, hidden status breaking on attack)*
+
+⚔️ 5e Fantasy — Solo Campaign
+
+**Chapter Three: The Ledger (continued)**
+
+The two guards split up. One moves toward the stairwell. The other — closer, heavier — turns to scan the cellar. There's a row of wine barrels between you and the far exit. The lantern on the wall throws hard shadows.
+
+⚔️ COMBAT — Round 2
+Initiative: Veyra (18) → Guard A (12) → Guard B (9)
+
+[PC TURN: Veyra]
+  Action:       ✅ available
+  Bonus Action: ✅ available
+  Reaction:     ✅ available
+
+ENEMIES
+  Guard A (stairwell): Uninjured
+  Guard B (near): Uninjured
+
+The barrels are right beside you — total cover from Guard B if you step behind them. Guard A is at the far end of the cellar and can't see you from the stairwell.
+
+What do you do?
+A) [Bonus Action] Cunning Action: Hide behind the barrels. [Action] Crossbow shot at Guard B from cover once he moves past.
+B) [Action] Crossbow shot at Guard B now — he's close, you have angle.
+C) [Action] Sprint for the exit past Guard A. [Bonus Action] Cunning Action: Dash for extra movement.
+D) Something else entirely — just tell me.
+
+---
+
+*(Player: "A — hide first, then shoot.")*
+
+You slip behind the barrels and go still.
+
+🎲 Stealth — d20 + 5 = 14 + 5 = 19.
+
+Guard B's Passive Perception is 11. The shadows swallow you.
+
+Guard A descends the stairwell — footsteps, then silence. Guard B moves to where you were standing, crossbow raised at nothing. He scans left, scans right.
+
+"Clear?" Guard A calls from the stairs.
+
+Guard B doesn't answer yet. He's two feet from your barrel.
+
+Your action. You're hidden from both guards. An attack will break your hidden status — but it triggers Sneak Attack.
+
+[PC TURN: Veyra — Hidden]
+  Action:       ✅ available
+  Bonus Action: ✗ used — Cunning Action: Hide
+  Reaction:     ✅ available
+
+*(Player: "Shoot Guard B.")*
+
+You come up from behind the barrel and fire.
+
+🎲 Crossbow attack — d20 + 5 = 16 + 5 = 21 vs AC 13. Hit. *(Attack had advantage — you were hidden. Used the higher roll.)*
+🎲 Damage — 1d6 + 3 (crossbow) + 2d6 (Sneak Attack) = 3 + 3 + 8 = 14 piercing.
+
+Guard B staggers and drops, the bolt through his throat. The sound of it — the thud, the scrape — carries.
+
+"Renn?" Guard A's voice, sharp now. Footsteps on the stairs again.
+
+Your hidden status is broken. Guard A doesn't know where you are yet, but he heard it.
+
+⚔️ COMBAT — Round 3
+Initiative: Veyra (18) → Guard A (12)
+
+[PC TURN: Veyra]
+  Action:       ✅ available
+  Bonus Action: ✅ available
+  Reaction:     ✅ available
+
+ENEMIES
+  Guard A: Uninjured — descending the stair, not yet in the cellar
+
+What do you do?
+A) [Bonus Action] Cunning Action: Hide again — step back behind the barrels before he rounds the corner.
+B) [Action] Crossbow shot at Guard A the moment he steps into the cellar. [Bonus Action] Cunning Action: Hide after.
+C) [Action] Dash for the exit while he's still on the stairs.
+D) Something else entirely — just tell me.
+
+Your Character
+**Veyra Ashcroft — Rogue (Arcane Trickster), Level 3**
+**HP:** 21/21 | **AC:** 14 | **Init:** +3
+**Resources:** Sneak Attack (auto, 2d6) | Cunning Action (auto) | Spell Slots 1st: 2/2
+
+*(Note: Veyra used Cunning Action: Hide as a bonus action, freeing her Action for the crossbow shot. The Stealth roll (19) beat Guard B's Passive Perception (11) — hidden status applies. The attack had advantage because the target was unaware of Veyra; only one roll is shown (highest of two). The moment the attack lands, hidden status breaks — Guard A hears the shot and will act on his turn. The menu for Round 3 immediately surfaces the option to re-hide before he enters the room.)*
+
+---
+
+**EXAMPLE 17 — ENEMY SPELL IDENTIFICATION (Arcana check, success vs. failure)**
+
+*(Demonstrates: DM describes spell effects without naming them, player with Arcana proficiency prompted for identification check, success names the spell, failure leaves the player with visual information only)*
+
+⚔️ 5e Fantasy — Solo Campaign
+
+**Chapter Six: The Sanctum**
+
+The cultist at the altar raises her hands. Her lips move — words that leave a faint visual trace, like smoke written in the air and then erased. A sphere of absolute darkness blooms at the center of the room, twenty feet across, swallowing the candles and the floor and the space between you.
+
+*The sphere didn't come from her hands — it appeared at a point she targeted.*
+
+⚔️ COMBAT — Round 2
+Initiative: Rune (17) → Cultist (11)
+
+[PC TURN: Rune]
+  Action:       ✅ available
+  Bonus Action: ✅ available
+  Reaction:     ✅ available
+
+ENEMIES
+  Cultist at the altar: Uninjured
+
+The sphere is between you and her. You can't see through it, and you don't know if she can see through it either — or whether entering it would blind you entirely.
+
+You have Arcana proficiency. Do you want to use your Reaction to try to identify the spell?
+
+*(Player: "Yes — identify it.")*
+
+🎲 Arcana — d20 + 5 = 18 + 5 = 23. DC 17 (spell level 2 + 15). Success.
+
+*Darkness* — a 2nd-level spell, Evocation. The sphere creates magical darkness that normal sight and darkvision can't penetrate. It's not a concentration effect — it lasts 10 minutes or until dispelled. She doesn't need to maintain it.
+
+The sphere isn't covering her. She's inside it.
+
+What do you do?
+A) [Action] Cast *Faerie Fire* — the edge of the sphere, not inside. The light might catch her when she steps out. (Concentration — replaces your current concentration if active.)
+B) [Action] Move around the sphere's perimeter, staying in the light. She'll have to come out eventually.
+C) [Action] Step into the darkness and find her. (You'll be blinded, but so will she — unless she has other senses.)
+D) Something else entirely — just tell me.
+
+---
+
+*(Alternative outcome — failed Arcana check):*
+
+*(Player with lower Arcana: "I want to identify the spell.")*
+
+🎲 Arcana — d20 + 1 = 6 + 1 = 7. DC 17. Failure.
+
+You recognize the school of magic — Evocation, an area effect — but the specifics escape you. The darkness is absolute. You don't know if it has limits. You don't know if she can see through it.
+
+What do you do?
+A) [Action] Keep your distance and wait — she'll have to come to you eventually.
+B) [Action] Step to the sphere's edge and hurl a *Fire Bolt* through it, hoping the damage lands. (You're firing blind — attack has disadvantage.)
+C) [Action] Step into the darkness. If she can't see you either, it equalizes.
+D) Something else entirely — just tell me.
+
+Your Character
+**Rune Eldanar — Wizard, Level 5**
+**HP:** 32/32 | **AC:** 16 (Mage Armor) | **Init:** +3
+**Resources:** Spell Slots 1st: 4/4, 2nd: 3/3, 3rd: 2/2 | Arcane Recovery 1/1
+
+*(Note: The DM describes the spell's visible effects — the sphere of absolute darkness, the hand gestures, the targeting — without naming it. The player chooses to identify using their Reaction. On success (DC = 15 + spell level 2 = 17), the DM names the spell and gives the player mechanically relevant information: duration, no concentration, the caster's position inside. The player can now make an informed tactical choice. On failure, the player has only what they observed — enough to make decisions, but without the strategic clarity a successful check provides. The Reaction is consumed either way.)*

--- a/docs/gpt-instructions.md
+++ b/docs/gpt-instructions.md
@@ -124,6 +124,7 @@ Print only when the player uses the keyword:
 - `factions` — ⚔️ faction tracker with goals and attitudes
 - `stats` — 📊 proficient skills, tool proficiencies, passive values
 - `spells` — 🔮 prepared/known spell list with slots and concentration status
+- `party` — 🧑‍🤝‍🧑 compact one-line-per-member party status (HP, key resource, active conditions)
 - `recap` — 📋 concise session recap: key events, NPC interactions, decisions, unresolved threads
 - `output for new thread` — pause gameplay, generate structured Campaign State block
   (see dm-campaign-ops.md for the exact format)


### PR DESCRIPTION
## Summary

Implements all five feature opportunities identified in the 2026-06-27 audit.

## Features

### F1 — Shopping & merchant interaction (dm-campaign-ops.md)
Expanded the minimal finding-fix into a full protocol:
- **Browsing format**: DM proactively presents 3–5 curated items based on party level and visible gaps; availability table by setting tier (village → major city → black market)
- **Merchant personalities**: five types (efficient, suspicious, boastful, reluctant, desperate) that affect haggling DC and whether the merchant answers questions
- **Faction-gated items**: Allied status unlocks off-menu stock; Hostile status may trigger a report to the faction; narrated naturally ("she glances at the sigil on your cloak")
- **Expanded pricing**: magic item cost ranges, potions table, economy adjustments
- **Low-coin warning**: flags when a purchase would leave the PC below 5 gp

### F2 — Hiding in combat worked example (dm-core-rules.md, Example 16)
Full combat sequence showing:
- Cunning Action: Hide as bonus action, Action preserved for attack
- Stealth roll vs. Passive Perception (both guards resolved separately)
- Advantage on attack from hidden, Sneak Attack triggered
- Hidden status breaking on attack; Round 3 menu immediately resurfaces re-hide option
- Note explains advantage roll presentation (highest of two, one shown)

### F3 — Companion personality events (dm-campaign-ops.md, new section)
New section defining when and how to deliver companion beats:
- **Trigger priority**: open personal thread → recent story event → default every 2–3 long rests
- **Delivery format**: 2–4 sentences + one companion line/action; open hook; no forced resolution; graceful deflection
- **Guardrails**: no interrupting active scenes; no back-to-back same beat type; no manufactured drama
- **Tracking**: open threads noted in Campaign State TONE & CONTEXT NOTES
- **Four concrete examples** using existing Lira/Garen cast (rest conversation, post-battle silence, unprompted kindness, post-disagreement quiet)

### F4 — Enemy spell identification worked example (dm-core-rules.md, Example 17)
Full worked example with two complete outcomes:
- **Success** (DC 17 met): spell named, duration/concentration/caster position revealed; choice menu reflects full tactical picture (*Darkness* neutralized by *Faerie Fire* or movement options)
- **Failure**: visual information only; choices made under uncertainty (fire blind, wait, step in); both outcomes show realistic player agency

### F5 — `party` on-demand command (3 files)
- **dm-core-rules.md**: full command definition with format spec (one line per member: Name, Class/Level, HP, key resource, condition if active) and worked example using Theron/Lira/Garen
- **claude-instructions.md**: added to ON-DEMAND COMMANDS list
- **gpt-instructions.md**: added to ON-DEMAND COMMANDS list

## Files changed
| File | Changes |
|------|---------|
| `docs/dm-core-rules.md` | `party` command definition + format example; Example 16 (Hiding); Example 17 (Spell ID) |
| `docs/dm-campaign-ops.md` | Expanded Shopping section; new Companion Personality Events section |
| `docs/claude-instructions.md` | `party` added to ON-DEMAND COMMANDS |
| `docs/gpt-instructions.md` | `party` added to ON-DEMAND COMMANDS |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)