### PR TITLE
fix: set audit schedule to first Friday of each month at 9am CT

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -8,9 +8,9 @@ on:
   # On-demand: create an issue with the "audit" label
   issues:
     types: [labeled]
-  # Scheduled: runs every other Monday at 9am CT
+  # Scheduled: first Friday of each month at 9am CT (14:00 UTC / CDT; 15:00 UTC / CST)
   schedule:
-    - cron: '0 14 * * 5'  # 14:00 UTC = 9:00 AM CT, every Friday
+    - cron: '0 14 1-7 * 5'  # day 1-7 + Friday = first Friday of the month
   # Manual trigger from Actions tab
   workflow_dispatch:
 

--- a/ops/solo-ai-dm-ops.md
+++ b/ops/solo-ai-dm-ops.md
@@ -107,7 +107,7 @@ Three ways to trigger:
 
 | Method | How | When to use |
 |--------|-----|-------------|
-| **Scheduled** | Automatic — every Monday 9am CT | Ongoing quality baseline |
+| **Scheduled** | Automatic — first Friday of each month, 9am CT | Ongoing quality baseline |
 | **Label** | Create issue, add `audit` label | After a big edit pass or playtest |
 | **Manual** | Repo → Actions → "AI DM Audit" → Run workflow | Any time |
 
@@ -240,13 +240,18 @@ for public repos, which is more than enough).
 
 ## Adjusting the Schedule
 
-The audit runs every Monday at 9am CT by default. To change it, edit the cron
-expression in `.github/workflows/audit.yml`:
+The audit runs on the first Friday of each month at 9am CT by default. To change it,
+edit the cron expression in `.github/workflows/audit.yml`:
 
 ```yaml
 schedule:
-  - cron: '0 14 1,15 * *'  # 1st and 15th of each month at 9am CT
+  - cron: '0 14 1-7 * 5'   # first Friday of each month at 9am CT (14:00 UTC / CDT)
+  # - cron: '0 14 * * 5'   # every Friday at 9am CT
+  # - cron: '0 14 1,15 * *' # 1st and 15th of each month at 9am CT
 ```
+
+Note: cron runs at 14:00 UTC, which is 9am CDT (Mar–Nov) and 8am CST (Nov–Mar).
+Cron has no DST awareness — this is the standard tradeoff for CT schedules.
 
 To disable scheduled runs entirely, remove the `schedule` trigger and keep only
 `issues` and `workflow_dispatch`.


### PR DESCRIPTION
## What was wrong

Three-way inconsistency in the audit schedule:

| Location | Said |
|---|---|
| `audit.yml` comment | "every other Monday at 9am CT" |
| `audit.yml` cron | `0 14 * * 5` — every **Friday**, no biweekly logic |
| `ops/solo-ai-dm-ops.md` table | "every Monday 9am CT" |
| `ops/solo-ai-dm-ops.md` example cron | `0 14 1,15 * *` — 1st and 15th of month |

## What changed

**`audit.yml`** — cron updated to `0 14 1-7 * 5`
- `1-7` restricts to the first 7 days of the month
- `5` restricts to Fridays
- Together these match only when it's both a Friday and one of the first 7 days — always the first Friday of the month

**`ops/solo-ai-dm-ops.md`** — two places updated:
- Schedule table: "first Friday of each month, 9am CT"
- "Adjusting the Schedule" section: correct description, alternative cron examples, DST note

## DST note

14:00 UTC = 9am CDT (Mar–Nov) and 8am CST (Nov–Mar). Cron has no DST awareness — this is the standard tradeoff for US timezone schedules.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)